### PR TITLE
Bring back the revised grid

### DIFF
--- a/_layouts/log-entry.html
+++ b/_layouts/log-entry.html
@@ -11,18 +11,18 @@ layout: default
 <article class="post-content">
 
   <dl class="log-data">
-    <dt class="log-data__label label--lat">Lat</dt>
-    <dd class="log-data__value value--lat">{{ page.lat }}</dd>
-    <dt class="log-data__label label--lon">Lon</dt>
-    <dd class="log-data__value value--lon">{{ page.lon }}</dd>
-    <dt class="log-data__label label--time">Time</dt>
-    <dd class="log-data__value value--time">{{ page.time }}</dd>
-    <dt class="log-data__label label--log"><span title="Distance (nautical miles)">Log</span></dt>
-    <dd class="log-data__value value--log">{{ page.log }} nm</dd>
-    <dt class="log-data__label label--cog"><span title="Course Over Ground">COG</span></dt>
-    <dd class="log-data__value value--cog">{{ page.cog }}</dd>
-    <dt class="log-data__label label--sog"><span title="Speed Over Ground (knots)">SOG</span></dt>
-    <dd class="log-data__value value--sog">{{ page.sog }} kt</dd>
+    <dt class="log-data__label">Lat</dt>
+    <dd class="log-data__value">{{ page.lat }}</dd>
+    <dt class="log-data__label">Lon</dt>
+    <dd class="log-data__value">{{ page.lon }}</dd>
+    <dt class="log-data__label">Time</dt>
+    <dd class="log-data__value">{{ page.time }}</dd>
+    <dt class="log-data__label"><span title="Distance (nautical miles)">Log</span></dt>
+    <dd class="log-data__value">{{ page.log }} nm</dd>
+    <dt class="log-data__label"><span title="Course Over Ground">COG</span></dt>
+    <dd class="log-data__value">{{ page.cog }}</dd>
+    <dt class="log-data__label"><span title="Speed Over Ground (knots)">SOG</span></dt>
+    <dd class="log-data__value">{{ page.sog }} kt</dd>
   </dl>
 
   <h2>Remarks</h2>

--- a/_sass/svbeouwlf/_log-entry.scss
+++ b/_sass/svbeouwlf/_log-entry.scss
@@ -2,17 +2,13 @@
   display: grid;
   grid-gap: 1px;
   background: #bbb;
-  grid-template-areas:
-    "label--lat label--lon"
-    "value--lat value--lon"
-    "label--time label--log"
-    "value--time value--log"
-    "label--cog label--sog"
-    "value--cog value--sog";
+  grid-template-rows: auto;
+  grid-template-columns: 1fr 1fr;
+  grid-auto-flow: row;
   @media screen and (min-width: $viewport-medium) {
-    grid-template-areas:
-      "label--lat label--lon label--time label--log label--cog label--sog"
-      "value--lat value--lon value--time value--log value--cog value--sog";
+    grid-template-columns: auto;
+    grid-template-rows: 1fr 1fr;
+    grid-auto-flow: column;
   }
 
   > * {
@@ -31,42 +27,5 @@
   &__value {
     color: #444;
     font-style: italic;
-  }
-
-  .label--lat {
-    grid-area: label--lat;
-  }
-  .value--lat {
-    grid-area: value--lat;
-  }
-  .label--lon {
-    grid-area: label--lon;
-  }
-  .value--lon {
-    grid-area: value--lon;
-  }
-  .label--time {
-    grid-area: label--time;
-  }
-  .value--time {
-    grid-area: value--time;
-  }
-  .label--log {
-    grid-area: label--log;
-  }
-  .value--log {
-    grid-area: value--log;
-  }
-  .label--cog {
-    grid-area: label--cog;
-  }
-  .value--cog {
-    grid-area: value--cog;
-  }
-  .label--sog {
-    grid-area: label--sog;
-  }
-  .value--sog {
-    grid-area: value--sog;
   }
 }


### PR DESCRIPTION
This fixes the bad merge that brought back the old version of the grid. With this version of the grid you don't need to create a label/value pair of classes and define a grid area for each pair that you need.

Brings back the grid work for #7 

### Mo Beta:

<img width="404" alt="Screen Shot 2019-03-19 at 9 32 08 PM" src="https://user-images.githubusercontent.com/1441652/54659304-83e2c880-4a8e-11e9-9719-f777c4679afd.png">
